### PR TITLE
Adding event mode scene tracking

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -779,7 +779,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &137153973
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3707,7 +3707,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &1041034522
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4239,7 +4239,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1269913373
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6576,6 +6576,9 @@ MonoBehaviour:
   creditsMenu: {fileID: 1269913372}
   creditsButton: {fileID: 1519786351}
   creditsBackButton: {fileID: 1368615645}
+  disclaimerMenu: {fileID: 1041034521}
+  disclaimerButton: {fileID: 651772310}
+  disclaimerBackButton: {fileID: 303397641}
   eventGoButton: {fileID: 784701051}
   eventModeBackButton: {fileID: 1783147218}
   eventModeInput: {fileID: 421675822}

--- a/Assets/Scripts/MainMenuController.cs
+++ b/Assets/Scripts/MainMenuController.cs
@@ -48,6 +48,20 @@ public class MainMenuController : MonoBehaviour
 
     }
 
+    private void Awake()
+    {
+        // If a player navigates back to the main menu while it is in event mode, we should disable free play to prevent users from getting around the event mode rules
+        // The only way event mode can be turned off is if quit (in the future we should add an 'event mode off' button
+        if (isEventMode())
+        {
+            freePlayButton.enabled = false;
+        }
+        else
+        {
+            freePlayButton.enabled = true;
+        }
+    }
+
     public void FreePlayStart()
     {
         SceneManager.LoadScene("Earth");

--- a/Assets/Scripts/SceneClick.cs
+++ b/Assets/Scripts/SceneClick.cs
@@ -6,15 +6,24 @@ using UnityEngine.SceneManagement;
 public class SceneClick : MonoBehaviour, IPointerDownHandler, IPointerUpHandler, IPointerClickHandler, IPointerEnterHandler, IPointerExitHandler
 {
     public string scene;
+    private int scenesVisited = 0;
 
     private void Awake()
     {
+        scenesVisited++;
         //Empty
     }
 
     public void OnPointerDown(PointerEventData eventData)
     {
-        SceneManager.LoadScene(scene);
+        if (MainMenuController.isEventMode() && scenesVisited >= MainMenuController.getMaxScenes())
+        {
+            Debug.Log("Max scenes reached");
+            SceneManager.LoadScene("MainMenu"); // TODO in the future, this will redirect to the next player menu and reset scenesVisited to 0
+        } else
+        {
+            SceneManager.LoadScene(scene);
+        }
     }
 
     public void OnPointerUp(PointerEventData eventData)


### PR DESCRIPTION
This PR makes the following changes:
- adds code to SceneClick script to check if event mode is on and if the max number of scenes have been visited.
- If the max number of scenes is visited, they are sent back to the main menu for now. This is until we get the 'Next player' menu done.
- Added code to the MainMenuController script so that if a player happens to navigate back to the main menu during their turn in event mode, the freeplay button is disabled. This is to prevent players from getting around the event mode rules. For now, event mode only turns off when you quit, but we can change this in the future if the sponsor wants.

**NOTE: I found a bug in the Earth scene and added it to the document. Also, only Jupiter and Earth seem to be clickable in the non vr planet map